### PR TITLE
Arbitrary code execution fix: Replace exec with execFile

### DIFF
--- a/node-latex-pdf.js
+++ b/node-latex-pdf.js
@@ -1,4 +1,4 @@
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
@@ -7,12 +7,12 @@ var selflatex = function(src_file,dest_file,callback){
     // split with src file name 
     var texname = src_file.split('/').splice(-1)[0].split('.')[0];
     // compile and 
-    exec("pdflatex -output-directory " + dest_file + " " + src_file, (err,stdout,stderr) => {
+    execFile("pdflatex", ["-output-directory", dest_file, src_file], (err,stdout,stderr) => {
         if (err) {
             callback(1,`pdflatex[1] error: ${err}`);
         }else{
             // compile second time to fit the usage
-            exec("pdflatex -output-directory " + dest_file + " " + src_file, (err,stdout,stderr) => {
+            execFile("pdflatex", ["-output-directory", dest_file, src_file], (err,stdout,stderr) => {
                 if (err) {
                     callback(1,`pdflatex[2] error: ${err}`);
                 }


### PR DESCRIPTION
### 📊 Metadata *

node-latex-pdf is a package that Convert your latex files to pdf format

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-latex-pdf/

### ⚙️ Description *

Used child_process.execFile() instead of child_process.exec().

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with execFile() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Installation

`npm i node-latex-pdf`

Run poc.js

```
var a =require("node-latex-pdf");
a("./","& touch HACKED",function(){})
```

`node poc.js`

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/105980226-9aaacb00-60ba-11eb-901a-ab3560e2563a.png)

After:
![image](https://user-images.githubusercontent.com/64132745/105980344-bca44d80-60ba-11eb-8dcb-d3ff015af414.png)


### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1797
